### PR TITLE
Dataset processing fixes for Unity.

### DIFF
--- a/decimate.py
+++ b/decimate.py
@@ -48,7 +48,7 @@ the_magic_constant = 42*42*4
 converter.configuration['textureCoordinateYFlipInMaterial'] = False
 converter.configuration['imageConverter'] = 'PngImageConverter' # 'BasisKtxImageConverter'
 
-def decimate(input, output, fallback_input=None, quiet=None, verbose=None, sloppy=False):
+def decimate(input, output, quiet=None, verbose=None, sloppy=False, simplify=True):
 
     if quiet:
         importer.flags |= trade.ImporterFlags.QUIET
@@ -119,9 +119,9 @@ def decimate(input, output, fallback_input=None, quiet=None, verbose=None, slopp
             # print(f"dim: {dim}")
 
             target_size0 = 0.1
-            target_count0 = 200
+            target_count0 = 1000
             target_size1 = 1.0
-            target_count1 = 500
+            target_count1 = 5000
             size = (dim.x + dim.y + dim.z) / 3
             lerp_fraction = math.lerp_inverted(target_size0, target_size1, size)
             target_count = math.lerp(target_count0, target_count1, lerp_fraction)
@@ -148,7 +148,7 @@ def decimate(input, output, fallback_input=None, quiet=None, verbose=None, slopp
 
             # Running the simplifier only if simplification is actually desired
             if target < 1.0:
-                meshoptimizer.configuration['simplify'] = True
+                meshoptimizer.configuration['simplify'] = simplify
                 # You might want to enable this if the non-sloppy simplification fails
                 # to reach the target by a wide margin
                 meshoptimizer.configuration['simplifySloppy'] = sloppy  # temp

--- a/decimate.py
+++ b/decimate.py
@@ -94,8 +94,12 @@ def decimate(input, output, fallback_input=None, quiet=None, verbose=None, slopp
         # to fiddle with this heuristics, another option is calculating the mesh
         # AABB but that won't do the right thing for planar meshes.
         if not scaled_mesh.is_indexed:
+            converter.end_file()
+            importer.close()
             assert False, "i didn't bother with index-less variant for the heuristics, sorry"
         if scaled_mesh.primitive != MeshPrimitive.TRIANGLES:
+            converter.end_file()
+            importer.close()
             assert False, "i didn't bother with non-triangle meshes either, sorry"
         triangle_count = scaled_mesh.index_count//3
         total_source_tris += triangle_count
@@ -151,7 +155,7 @@ def decimate(input, output, fallback_input=None, quiet=None, verbose=None, slopp
                 meshoptimizer.configuration['simplifyTargetIndexCountThreshold'] = target
                 decimated_mesh = meshoptimizer.convert(mesh)
 
-            # If simplifcation isn't desired or if it caused the mesh to disappear, run
+            # If simplification isn't desired or if it caused the mesh to disappear, run
             # just the nondestructive optimizations
             if target >= 1.0 or decimated_mesh.vertex_count == 0:
                 meshoptimizer.configuration['simplify'] = False

--- a/decimate.py
+++ b/decimate.py
@@ -82,7 +82,6 @@ def decimate(input, output, quiet=None, verbose=None, sloppy=False, simplify=Tru
     total_source_tris = 0
     total_target_tris = 0
     total_simplified_tris = 0
-    num_meshes = importer.mesh_count
     for i in range(importer.mesh_count):
         mesh = importer.mesh(i)
 
@@ -93,19 +92,20 @@ def decimate(input, output, quiet=None, verbose=None, sloppy=False, simplify=Tru
         # Calculate total triangle area of the *transformed* mesh. You might want
         # to fiddle with this heuristics, another option is calculating the mesh
         # AABB but that won't do the right thing for planar meshes.
-        if not scaled_mesh.is_indexed:
-            converter.end_file()
-            importer.close()
-            assert False, "i didn't bother with index-less variant for the heuristics, sorry"
-        if scaled_mesh.primitive != MeshPrimitive.TRIANGLES:
-            converter.end_file()
-            importer.close()
-            assert False, "i didn't bother with non-triangle meshes either, sorry"
-        triangle_count = scaled_mesh.index_count//3
-        total_source_tris += triangle_count
+        if simplify:
+            if not scaled_mesh.is_indexed:
+                converter.end_file()
+                importer.close()
+                assert False, "i didn't bother with index-less variant for the heuristics, sorry"
+            if scaled_mesh.primitive != MeshPrimitive.TRIANGLES:
+                converter.end_file()
+                importer.close()
+                assert False, "i didn't bother with non-triangle meshes either, sorry"
+            triangle_count = scaled_mesh.index_count//3
+            total_source_tris += triangle_count
 
         # Perform decimation only if there's actually something, heh
-        if triangle_count:
+        if simplify and triangle_count > 0:
 
             # get scaled bounding box
             positions = scaled_mesh.attribute(trade.MeshAttribute.POSITION)

--- a/decimate.py
+++ b/decimate.py
@@ -45,7 +45,7 @@ the_magic_constant = 42*42*4
 
 # glTF converter defaults. This makes it work with quantized inputs, however
 # decimation will un-quantize again.
-converter.configuration['textureCoordinateYFlipInMaterial'] = True
+converter.configuration['textureCoordinateYFlipInMaterial'] = False
 converter.configuration['imageConverter'] = 'PngImageConverter' # 'BasisKtxImageConverter'
 
 def decimate(input, output, fallback_input=None, quiet=None, verbose=None, sloppy=False):

--- a/get_scene_object_glbs.py
+++ b/get_scene_object_glbs.py
@@ -287,13 +287,13 @@ def main():
             job.source_path = os.path.join(parts[0], parts[1])
             assert len(parts) == 2
             job.dest_path = os.path.join(OUTPUT_DIR, FPHAB_DIR_NAME, rel_path)
-            job.simplify = True
+            job.simplify = False
             jobs.append(job)
         else:
             job = Job()
             job.source_path = os.path.join(args.fphab_root_dir, rel_path)
             job.dest_path = os.path.join(OUTPUT_DIR, FPHAB_DIR_NAME, rel_path)
-            job.simplify = True
+            job.simplify = False
             jobs.append(job)
 
     # Add ycb objects

--- a/get_scene_object_glbs.py
+++ b/get_scene_object_glbs.py
@@ -107,9 +107,9 @@ def process_model(args):
         )
     except:
         try:
-            print(f"Unable to decimate: {job.source_path}. Trying sloppy.")
+            print(f"Unable to decimate: {job.source_path}. Trying passthrough (no decimation).")
             source_tris, target_tris, simplified_tris = decimate.decimate(
-                job.source_path, job.dest_path, quiet=True, sloppy=job.simplify
+                job.source_path, job.dest_path, quiet=True, decimate=False
             )
         except:
             print(f"Unable to decimate: {job.source_path}")


### PR DESCRIPTION
This is a set of fixes for processing the data folder for usage within Unity.
* Y-Flip texture coordinates in materials.
    * All materials were flipped prior to this change.
    * ![image](https://github.com/eundersander/habitat-lab/assets/110583667/db437f84-fcea-436e-ab58-3003cd260468)
* More permissive decimation.
    * Optimization targets are relaxed.
    * "Sloppy" optimizations are now only done as a fallback.
* Data processing input is now defined as "jobs". Input path, output path and parameters are defined upfront for each file.
* Added error and skipped file count console outputs.
* Ycb objects and spot are not decimated anymore.
    * Results were unsatisfactory. Because these objects are the most user-facing, I think that it's preferable to use them as-is.
* Fix for picking up the scene glb.

---

Example `launch.json`:
```
{
        "name": "Process Data",
        "type": "python",
        "request": "launch",
        "program": "get_scene_object_glbs.py",
        "args": [
            "--fphab-root-dir",
                "../fphab/",
            "--fp-models-root-dir",
                "../fp-models/",
            "--scenes",
                "102344193",
                "102344280",
                "102817200",
                "103997424_171030444",
                "103997541_171030615",
        ],
        "console": "integratedTerminal",
        "cwd": "${workspaceFolder}"
}
```